### PR TITLE
feat: add switchProp function

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,12 +15,27 @@ Useful interpolated functions for [styled-components](https://github.com/styled-
 Play with it on [WebpackBin](https://www.webpackbin.com/bins/-Kel3KgddZSrD5oK0fIk)
 
 ```jsx
-import styled from 'styled-components'
-import { prop, ifProp } from 'styled-tools'
+import styled, { css } from 'styled-components'
+import { prop, ifProp, switchProp } from 'styled-tools'
 
 const Button = styled.button`
   color: ${prop('color', 'red')};
   font-size: ${ifProp({ size: 'large' }, '20px', '14px')};
+
+  ${switchProp('type', {
+    dark: css`
+      background-color: blue;
+      border: 1px solid blue;
+    `,
+    darker: css`
+      background-color: mediumblue;
+      border: 1px solid mediumblue;
+    `,
+    darkest: css`
+      background-color: darkblue;
+      border: 1px solid darkblue;
+    `,
+  })};
 `
 
 // renders with color: blue
@@ -31,6 +46,9 @@ const Button = styled.button`
 
 // renders with font-size: 20px
 <Button size="large" />
+
+// renders with background-color: mediumblue & border: 1px solid mediumblue
+<Button type="darker">
 ```
 
 A more complex example:
@@ -93,6 +111,42 @@ const Button = styled.button`
  color: ${ifProp(['transparent', 'accent'], palette('secondary', 0))};
  font-size: ${ifProp({ size: 'large' }, '20px', ifProp({ size: 'medium' }, '16px', '12px'))};
 `
+```
+
+Returns **any** 
+
+### switchProp
+
+Switches on a given prop. Returns the value or function for a given prop value.
+
+**Parameters**
+
+-   `needle` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** 
+-   `switches` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+
+**Examples**
+
+```javascript
+import styled, { css } from 'styled-components'
+import { switchProp } from 'styled-theme'
+
+const Button = styled.button`
+ font-size: ${switchProp('size', {
+   small: prop('theme.sizes.sm', '12px'),
+   large: prop('theme.sizes.lg', '20px'),
+   default: prop('theme.sizes.md', '16px'),
+ })};
+ ${switchProp('theme.kind', {
+   light: css`
+     color: LightBlue;
+   `,
+   dark: css`
+     color: DarkBlue;
+   `,
+ })}
+`
+
+<Button size="large" theme={{ kind: 'light' }} />
 ```
 
 Returns **any** 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ const Button = styled.button`
   color: ${prop('color', 'red')};
   font-size: ${ifProp({ size: 'large' }, '20px', '14px')};
 
-  ${switchProp('type', {
+  ${switchProp('theme', {
     dark: css`
       background-color: blue;
       border: 1px solid blue;
@@ -48,7 +48,7 @@ const Button = styled.button`
 <Button size="large" />
 
 // renders with background-color: mediumblue & border: 1px solid mediumblue
-<Button type="darker">
+<Button theme="darker">
 ```
 
 A more complex example:

--- a/src/index.js
+++ b/src/index.js
@@ -44,3 +44,33 @@ export const ifProp = (needle: string | string[] | Object, pass?: any, fail?: an
     }
     return result ? pass : fail
   }
+
+/**
+ * Switches on a given prop. Returns the value or function for a given prop value.
+ * @example
+ * import styled, { css } from 'styled-components'
+ * import { switchProp } from 'styled-theme'
+ *
+ * const Button = styled.button`
+ *  font-size: ${switchProp('size', {
+ *    small: prop('theme.sizes.sm', '12px'),
+ *    large: prop('theme.sizes.lg', '20px'),
+ *    default: prop('theme.sizes.md', '16px'),
+ *  })};
+ *  ${switchProp('theme.kind', {
+ *    light: css`
+ *      color: LightBlue;
+ *    `,
+ *    dark: css`
+ *      color: DarkBlue;
+ *    `,
+ *  })}
+ * `
+ *
+ * <Button size="large" theme={{ kind: 'light' }} />
+ */
+export const switchProp = (needle: string, switches: Object): any =>
+  (props: Object = {}): any => {
+    const propType = _get(props, needle)
+    return _get(switches, propType)
+  }

--- a/test/index.js
+++ b/test/index.js
@@ -1,4 +1,4 @@
-import { prop, get, ifProp } from '../src'
+import { prop, get, ifProp, switchProp } from '../src'
 
 describe('prop', () => {
   it('handles string', () => {
@@ -90,5 +90,18 @@ describe('ifProp', () => {
   it('handles deep object needle', () => {
     expect(ifProp({ 'foo.bar': 'ok' }, 'yes', 'no')({ foo: { bar: 'ok' } })).toBe('yes')
     expect(ifProp({ 'foo.bar': 'ok' }, 'yes', 'no')({ foo: { bar: 'no' } })).toBe('no')
+  })
+})
+
+describe('switchProp', () => {
+  it('handles switching', () => {
+    expect(switchProp('type', { red: 'red', blue: 'blue' })()).toBeUndefined()
+    expect(switchProp('type', { red: 'red', blue: 'blue' })({ type: 'red' })).toBe('red')
+    expect(switchProp('type', { red: 'red', blue: 'blue' })({ type: 'blue' })).toBe('blue')
+  })
+
+  it('handles deep switching', () => {
+    expect(switchProp('foo.bar', { red: 'red', blue: 'blue' })({ foo: { bar: 'red' } })).toBe('red')
+    expect(switchProp('foo.bar', { red: 'red', blue: 'blue' })({ foo: { bar: 'blue' } })).toBe('blue')
   })
 })


### PR DESCRIPTION
This pr adds a `switchProp` function as described in #26 

```jsx
import styled, { css } from 'styled-components'
import { switchProp } from 'styled-tools'

const Button = styled.button`
  ${switchProp('type', {
    dark: css`
      background-color: blue;
      border: 1px solid blue;
    `,
    darker: css`
      background-color: mediumblue;
      border: 1px solid mediumblue;
    `,
    darkest: css`
      background-color: darkblue;
      border: 1px solid darkblue;
    `,
  })};
`

// renders with background-color: mediumblue & border: 1px solid mediumblue
<Button type="darker">
```

I'm not the best with naming things so if any of the names are wrong/awkward let me know and I can fix them.

I also was not sure of how many tests to add so I stuck with a few basic ones. I can add more if needed.