### PR TITLE
Add es modules output format

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,11 +1,3 @@
 {
-  "presets": [
-    ["env", {
-      "targets": {
-        "browsers": "last 2 versions"
-      }
-    }],
-    "stage-2"
-  ],
-  "plugins": ["transform-flow-strip-types"]
+  "presets": ["./.babelrc.js"]
 }

--- a/.babelrc.js
+++ b/.babelrc.js
@@ -1,0 +1,15 @@
+const { BABEL_ENV, NODE_ENV } = process.env;
+const modules = BABEL_ENV === 'cjs' || NODE_ENV === 'test' ? 'commonjs' : false;
+
+module.exports = {
+  presets: [
+    ['env', {
+      targets: {
+        browsers: 'last 2 versions',
+      },
+      modules
+    }],
+    'stage-2',
+  ],
+  plugins: ['transform-flow-strip-types'],
+};

--- a/index.js
+++ b/index.js
@@ -1,1 +1,0 @@
-module.exports = require('./dist')

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Utilities for styled-components",
   "license": "MIT",
   "repository": "diegohaz/styled-tools",
-  "main": "index.js",
+  "main": "dist/index.cjs.js",
+  "module": "dist/index.es.js",
   "author": {
     "name": "Diego Haz",
     "email": "hazdiego@gmail.com",
@@ -14,8 +15,7 @@
     "node": ">=6"
   },
   "files": [
-    "dist",
-    "index.js"
+    "dist"
   ],
   "scripts": {
     "test": "jest",
@@ -25,9 +25,11 @@
     "flow": "flow check",
     "flow-typed": "flow-typed install",
     "docs": "documentation readme src --section=API",
-    "clean": "del dist",
+    "clean": "del dist && make-dir dist",
     "prebuild": "npm run docs && npm run clean",
-    "build": "babel src -d dist",
+    "build": "npm run build:cjs && npm run build:es",
+    "build:cjs": "cross-env BABEL_ENV=cjs babel src --out-file dist/index.cjs.js",
+    "build:es": "cross-env BABEL_ENV=es babel src --out-file dist/index.es.js",
     "watch": "npm-watch",
     "patch": "npm version patch && npm publish",
     "minor": "npm version minor && npm publish",
@@ -57,6 +59,7 @@
     "babel-plugin-transform-flow-strip-types": "^6.21.0",
     "babel-preset-env": "^1.1.8",
     "babel-preset-stage-2": "^6.18.0",
+    "cross-env": "^5.1.3",
     "del-cli": "^1.0.0",
     "documentation": "^5.3.2",
     "eslint": "^4.15.0",
@@ -67,6 +70,7 @@
     "flow-bin": "^0.63.1",
     "flow-typed": "^2.0.0",
     "jest-cli": "^22.0.6",
+    "make-dir-cli": "^1.0.0",
     "npm-watch": "^0.3.0",
     "opn-cli": "^3.1.0"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1586,6 +1586,13 @@ create-error-class@^3.0.0:
   dependencies:
     capture-stack-trace "^1.0.0"
 
+cross-env@^5.1.3:
+  version "5.1.3"
+  resolved "https://registry.yarnpkg.com/cross-env/-/cross-env-5.1.3.tgz#f8ae18faac87692b0a8b4d2f7000d4ec3a85dfd7"
+  dependencies:
+    cross-spawn "^5.1.0"
+    is-windows "^1.0.0"
+
 cross-spawn@^5.0.1, cross-spawn@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-5.1.0.tgz#e8bd0efee58fcff6f8f94510a0a554bbfa235449"
@@ -2505,7 +2512,7 @@ git-url-parse@^6.0.1:
   dependencies:
     git-up "^2.0.0"
 
-github-slugger@1.2.0, github-slugger@^1.1.1:
+github-slugger@1.2.0, github-slugger@^1.0.0, github-slugger@^1.1.1:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/github-slugger/-/github-slugger-1.2.0.tgz#8ada3286fd046d8951c3c952a8d7854cfd90fd9a"
   dependencies:
@@ -3232,7 +3239,7 @@ is-whitespace-character@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-whitespace-character/-/is-whitespace-character-1.0.1.tgz#9ae0176f3282b65457a1992cdb084f8a5f833e3b"
 
-is-windows@^1.0.1:
+is-windows@^1.0.0, is-windows@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-1.0.1.tgz#310db70f742d259a16a369202b51af84233310d9"
 
@@ -3840,6 +3847,13 @@ lru-cache@^4.0.1:
   dependencies:
     pseudomap "^1.0.2"
     yallist "^2.1.2"
+
+make-dir-cli@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/make-dir-cli/-/make-dir-cli-1.0.0.tgz#1c770e5c731106c51c11095b02beaa6c9749dc59"
+  dependencies:
+    make-dir "^1.0.0"
+    meow "^3.7.0"
 
 make-dir@^1.0.0:
   version "1.1.0"
@@ -4933,6 +4947,10 @@ remark-parse@^4.0.0:
 remark-slug@^4.0.0:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/remark-slug/-/remark-slug-4.2.3.tgz#8d987d0e5e63d4a49ea37b90fe999a3dcfc81b72"
+  dependencies:
+    github-slugger "^1.0.0"
+    mdast-util-to-string "^1.0.0"
+    unist-util-visit "^1.0.0"
 
 remark-stringify@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
- Add second entry point to *package.json*:
  - the `main` field: still the same CommonJS module
  - the `module` field: the newly created ES Modules file (this is used by Rollup, Webpack, ...)
- Add [cross-env](https://github.com/kentcdodds/cross-env) to set `BABEL_ENV` without worrying about the platform.
- Add *.babelrc.js* to conditionally assign [babel-preset-env](https://github.com/babel/babel/tree/master/packages/babel-preset-env#modules)'s `modules` option.
- Add [make-dir](https://github.com/sindresorhus/make-dir) to avoid errors due to using babel's `--out-file` option.

Fixes #37 