### PR TITLE
Update typings to handle nested ifProp

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -54,13 +54,17 @@ export function ifProp<Props, Pass = undefined, Fail = undefined>(
   test: Needle<Props> | Needle<Props>[] | { [key: string]: any },
   pass?: Pass,
   fail?: Fail
-): <P = Props>(props?: P) => Pass extends Function ? ReturnType<Pass> : Pass | Fail extends Function ? ReturnType<Fail> : Fail;
+): <P = Props>(props?: P) =>
+  (Pass extends (...args: any) => any ? ReturnType<Pass> : Pass ) 
+  | (Fail extends (...args: any) => any ? ReturnType<Fail> : Fail);
 
 export function ifNotProp<Props, Pass = undefined, Fail = undefined>(
   test: Needle<Props> | Needle<Props>[] | { [key: string]: any },
   pass?: Pass,
   fail?: Fail
-): <P = Props>(props?: P) => Pass extends Function ? ReturnType<Pass> : Pass | Fail extends Function ? ReturnType<Fail> : Fail;
+): <P = Props>(props?: P) =>
+  (Pass extends (...args: any) => any ? ReturnType<Pass> : Pass) 
+  | (Fail extends (...args: any) => any ? ReturnType<Fail> : Fail);
 
 export function switchProp<Props, T = undefined, DefaultCase = undefined>(
   needle: Needle<Props>,

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -54,13 +54,13 @@ export function ifProp<Props, Pass = undefined, Fail = undefined>(
   test: Needle<Props> | Needle<Props>[] | { [key: string]: any },
   pass?: Pass,
   fail?: Fail
-): <P = Props>(props?: P) => Pass | Fail;
+): <P = Props>(props?: P) => Pass extends Function ? ReturnType<Pass> : Pass | Fail extends Function ? ReturnType<Fail> : Fail;
 
 export function ifNotProp<Props, Pass = undefined, Fail = undefined>(
   test: Needle<Props> | Needle<Props>[] | { [key: string]: any },
   pass?: Pass,
   fail?: Fail
-): <P = Props>(props?: P) => Pass | Fail;
+): <P = Props>(props?: P) => Pass extends Function ? ReturnType<Pass> : Pass | Fail extends Function ? ReturnType<Fail> : Fail;
 
 export function switchProp<Props, T = undefined, DefaultCase = undefined>(
   needle: Needle<Props>,

--- a/types/tests.ts
+++ b/types/tests.ts
@@ -40,6 +40,7 @@ ifProp("a", 1, 2)({ a: true }) as number;
 ifProp("a", "a")({ a: true }) as string;
 ifProp("a", "a")({ a: true }) as undefined;
 ifProp("a")({ a: true }) as undefined;
+ifProp("a", ifProp("b", "5", "0"), ifProp("c", "5", "0"))({ a: false, b: true, c: false }) as string;
 
 ifNotProp("a", true)({ a: true }) as boolean;
 ifNotProp("a", true)({ a: true }) as undefined;
@@ -49,6 +50,7 @@ ifNotProp("a", 1, 2)({ a: true }) as number;
 ifNotProp("a", "a")({ a: true }) as string;
 ifNotProp("a", "a")({ a: true }) as undefined;
 ifNotProp("a")({ a: true }) as undefined;
+ifNotProp("a", ifProp("b", "5", "0"), ifProp("c", "5", "0"))({ a: false, b: true, c: false }) as string;
 
 switchProp("a", { a: true, b: 1 })({ a: "a" }) as boolean;
 switchProp("a", { a: true, b: 1 })({ a: "a" }) as number;

--- a/types/tests.ts
+++ b/types/tests.ts
@@ -50,7 +50,7 @@ ifNotProp("a", 1, 2)({ a: true }) as number;
 ifNotProp("a", "a")({ a: true }) as string;
 ifNotProp("a", "a")({ a: true }) as undefined;
 ifNotProp("a")({ a: true }) as undefined;
-ifNotProp("a", ifProp("b", "5", "0"), ifProp("c", "5", "0"))({ a: false, b: true, c: false }) as string;
+ifNotProp("a", ifNotProp("b", "5", "0"), ifNotProp("c", "5", "0"))({ a: false, b: true, c: false }) as string;
 
 switchProp("a", { a: true, b: 1 })({ a: "a" }) as boolean;
 switchProp("a", { a: true, b: 1 })({ a: "a" }) as number;


### PR DESCRIPTION
Current typings do not work for this form:
```
const ifSessionStartOrWholeBorder = ifProp(
  { sessionPart: "start" },
  "5px",
  ifProp({ sessionPart: "whole" }, "5px", "0px"),
) 
```

I've changed it a bit, so that if function is passed it will return its return type instead of function itself